### PR TITLE
- fixed: correctly handle merging of schemas with selectors

### DIFF
--- a/lib/collection2.js
+++ b/lib/collection2.js
@@ -44,6 +44,22 @@ Mongo.Collection.prototype.attachSchema = function c2AttachSchema(ss, options) {
     if (typeof selector === "object") {
       // we need an array to hold multiple schemas
       obj._c2._simpleSchemas = obj._c2._simpleSchemas || [];
+
+      var foundExistingSS = null;
+      for (index = 0; index < obj._c2._simpleSchemas.length; ++index) {
+        //console.log("comparing index "+index+" with selector: %o", selector);
+        var currSS = obj._c2._simpleSchemas[index];
+        if (JSON.stringify(currSS.selector) == JSON.stringify(selector)) {
+          //console.log("found SS for selector ",selector," SS: ",obj._c2._simpleSchemas[index]);
+
+          foundExistingSS = currSS;
+          if (options.replace !== true) {
+            ss = new SimpleSchema([foundExistingSS, ss]);
+          }
+          obj._c2._simpleSchemas.splice(index, 1); // remove existing SS for this selector. updated version will be pushed below.
+        }
+      }
+
       obj._c2._simpleSchemas.push({
         schema: new SimpleSchema(ss),
         selector: selector,

--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@
 Package.describe({
   name: "aldeed:collection2-core",
   summary: "Core package for aldeed:collection2",
-  version: "1.1.0",
+  version: "1.1.1",
   git: "https://github.com/aldeed/meteor-collection2-core.git"
 });
 


### PR DESCRIPTION
Problem: when calling attachSchema() with the selector option on a collection which already has a schema for that selector, the schemas are not merged or replaced. Instead the new one is just added to the array and is not effective during validation.

I fixed this, so that schemas with selectors are properly merged or replaced and not stacked.