### PR TITLE
Bug fix for attachSchema with {replace:true} option

### DIFF
--- a/lib/collection2.js
+++ b/lib/collection2.js
@@ -48,13 +48,14 @@ Mongo.Collection.prototype.attachSchema = function c2AttachSchema(ss, options) {
         schema: new SimpleSchema(ss),
         selector: selector,
       });
-      // remove any existing schemas without selector
-      obj._c2._simpleSchema && delete obj._c2._simpleSchema;
+      // remove any existing schemas without selecti
+      obj._c2._simpleSchema && delete obj._c2._simpleSchema
     } else {
       // Track the schema in the collection
       obj._c2._simpleSchema = ss;
       //remove any selector schemas 
-      obj._c2._simpleSchemas && delete obj._c2._simpleSchemas;
+      obj._c2._simpleSchemas && delete obj._c2._simpleSchemas
+      
     }
   }
 
@@ -119,6 +120,7 @@ _.each([Mongo.Collection, LocalCollection], function (obj) {
         }
       }
     }
+
     return null;
   };
 });
@@ -505,7 +507,7 @@ function defineDeny(c, options) {
     c.deny({
       insert: function(userId, doc) {
         // Referenced doc is cleaned in place
-        c.simpleSchema().clean(doc, {
+        c.simpleSchema(doc).clean(doc, {
           isModifier: false,
           // We don't do these here because they are done on the client if desired
           filter: false,
@@ -527,7 +529,7 @@ function defineDeny(c, options) {
       },
       update: function(userId, doc, fields, modifier) {
         // Referenced modifier is cleaned in place
-        c.simpleSchema().clean(modifier, {
+        c.simpleSchema(doc).clean(modifier, {
           isModifier: true,
           // We don't do these here because they are done on the client if desired
           filter: false,

--- a/lib/collection2.js
+++ b/lib/collection2.js
@@ -48,9 +48,13 @@ Mongo.Collection.prototype.attachSchema = function c2AttachSchema(ss, options) {
         schema: new SimpleSchema(ss),
         selector: selector,
       });
+      // remove any existing schemas without selector
+      obj._c2._simpleSchema && delete obj._c2._simpleSchema;
     } else {
       // Track the schema in the collection
       obj._c2._simpleSchema = ss;
+      //remove any selector schemas 
+      obj._c2._simpleSchemas && delete obj._c2._simpleSchemas;
     }
   }
 
@@ -115,7 +119,6 @@ _.each([Mongo.Collection, LocalCollection], function (obj) {
         }
       }
     }
-
     return null;
   };
 });


### PR DESCRIPTION
Hi,

The commit message describes the problem, but the code does it more concise:)

Bug fix for attachSchema with {replace:true} option where an existing  selector-less schema would not be removed when adding a schema with selector. [and the other way around]