### PR TITLE
Merge identical selector schemas

### DIFF
--- a/lib/collection2.js
+++ b/lib/collection2.js
@@ -62,10 +62,15 @@ Mongo.Collection.prototype.attachSchema = function c2AttachSchema(ss, options) {
           selector: selector,
         });
       } else {
-        // We found a schema with an identical selector in our array, merge with existing schema
-        console.log("Simple Schema", obj._c2._simpleSchemas[schemaIndex].schema);
-        // Schema with identical selector found. Extend existing schema
-        obj._c2._simpleSchemas[schemaIndex].schema = new SimpleSchema([obj._c2._simpleSchemas[schemaIndex].schema, ss]);
+        // We found a schema with an identical selector in our array,
+        if (options.replace !== true) {
+          // Merge with existing schema unless options.replace is `true`
+          obj._c2._simpleSchemas[schemaIndex].schema = new SimpleSchema([obj._c2._simpleSchemas[schemaIndex].schema, ss]);
+        } else {
+          // If options.repalce is `true` replace existing schema with new schema
+          obj._c2._simpleSchemas[schemaIndex].schema = ss;
+        }
+          
       }
 
     } else {

--- a/lib/collection2.js
+++ b/lib/collection2.js
@@ -42,12 +42,32 @@ Mongo.Collection.prototype.attachSchema = function c2AttachSchema(ss, options) {
 
   function attachTo(obj) {
     if (typeof selector === "object") {
+      // Index of existing schema with identical selector
+      var schemaIndex = -1;
+
       // we need an array to hold multiple schemas
       obj._c2._simpleSchemas = obj._c2._simpleSchemas || [];
-      obj._c2._simpleSchemas.push({
-        schema: new SimpleSchema(ss),
-        selector: selector,
+
+      // console.log(obj._c2._simpleSchemas);
+      // console.log(selector);
+
+      obj._c2._simpleSchemas.forEach(function (schema, index) {
+        if(schema.selector.type === selector.type) {
+          schemaIndex = index;
+        }
       });
+      if (schemaIndex === -1) {
+        obj._c2._simpleSchemas.push({
+          schema: new SimpleSchema(ss),
+          selector: selector,
+        });
+      } else {
+        // console.log("Simple Schema", ss);
+        console.log("Simple Schema", obj._c2._simpleSchemas[schemaIndex].schema);
+        // Schema with identical selector found. Extend existing schema
+        obj._c2._simpleSchemas[schemaIndex].schema = new SimpleSchema([obj._c2._simpleSchemas[schemaIndex].schema, ss]);
+      }
+
     } else {
       // Track the schema in the collection
       obj._c2._simpleSchema = ss;

--- a/lib/collection2.js
+++ b/lib/collection2.js
@@ -47,22 +47,22 @@ Mongo.Collection.prototype.attachSchema = function c2AttachSchema(ss, options) {
 
       // we need an array to hold multiple schemas
       obj._c2._simpleSchemas = obj._c2._simpleSchemas || [];
-
-      // console.log(obj._c2._simpleSchemas);
-      // console.log(selector);
-
+      
+      // Loop through existing schemas with selectors
       obj._c2._simpleSchemas.forEach(function (schema, index) {
-        if(schema.selector.type === selector.type) {
+        // if we find a schema with an identical selector, save it's index
+        if(_.isEqual(schema.selector, selector)) {
           schemaIndex = index;
         }
       });
       if (schemaIndex === -1) {
+        // We didn't find the schema in our array - push it into the array
         obj._c2._simpleSchemas.push({
           schema: new SimpleSchema(ss),
           selector: selector,
         });
       } else {
-        // console.log("Simple Schema", ss);
+        // We found a schema with an identical selector in our array, merge with existing schema
         console.log("Simple Schema", obj._c2._simpleSchemas[schemaIndex].schema);
         // Schema with identical selector found. Extend existing schema
         obj._c2._simpleSchemas[schemaIndex].schema = new SimpleSchema([obj._c2._simpleSchemas[schemaIndex].schema, ss]);


### PR DESCRIPTION
This fixes a bug that was introduced with 'Multiple Top Level Schemas' where attaching multiple top-level schemas with identical selectors would result in duplicate schemas in the top-level schema array.

This PR also supports replacing selector schemas with the existing replace option.