### PR TITLE
fix error on prototype-less objects, include test

### DIFF
--- a/package/collection2/collection2.js
+++ b/package/collection2/collection2.js
@@ -358,7 +358,7 @@ function doValidate(type, args, getAutoValues, userId, isFromTrustedCode) {
   for (var prop in doc) {
     // We omit prototype properties when cloning because they will not be valid
     // and mongo omits them when saving to the database anyway.
-    if (doc.hasOwnProperty(prop)) {
+    if (Object.prototype.hasOwnProperty.call(doc, prop)) {
       docToValidate[prop] = doc[prop];
     }
   }

--- a/tests/collection2.tests.js
+++ b/tests/collection2.tests.js
@@ -29,6 +29,24 @@ describe('collection2', function () {
     expect(mc.simpleSchema() instanceof SimpleSchema).toBe(true);
   });
 
+  it('handles prototype-less objects', function (done) {
+      const prototypelessTest = new Mongo.Collection('prototypelessTest');
+
+      prototypelessTest.attachSchema(new SimpleSchema({
+        foo: {
+          type: String
+        }
+      }));
+
+      const prototypelessObject = Object.create(null);
+      prototypelessObject.foo = 'bar'
+
+      prototypelessTest.insert(prototypelessObject, (error, newId) => {
+        expect(!!error).toBe(false);
+        done();
+      });
+    });
+
   if (Meteor.isServer) {
     // https://github.com/aldeed/meteor-collection2/issues/243
     it('upsert runs autoValue only once', function (done) {


### PR DESCRIPTION
Fix for https://github.com/aldeed/meteor-collection2-core/issues/8

Prevent error when passing a prototype-less object (typically created via `Object.create(null)`). 

Background:  relying on incoming objects to have standard prototype methods attached (hasOwnProperty, in this case) is increasingly unreliable, as numerous libraries have begun to use the prototype-less pattern for performance reasons (see [this common ESLint rule](http://eslint.org/docs/rules/no-prototype-builtins), for one example of discouragement) . This means that it's likely for any library to receive an object created elsewhere with the prototype-less approach, and calls to these built-in methods for arguments passed in should instead opt for something like `Object.prototype.call(obj, prop)`. 

In more practical terms, this was a breaking error an application I'm working on, and evidently for others based on the issue here. Rather than updating the syntax everywhere to ensure the object is copied into a full object as noted in the issue, patching the syntax will fix it once and for all.

Test included. Hoping to see it merged so we can switch back from using a fork.